### PR TITLE
added template logInfos

### DIFF
--- a/Mantle.API/Controllers/BaseWeaponCategoryController.cs
+++ b/Mantle.API/Controllers/BaseWeaponCategoryController.cs
@@ -6,6 +6,7 @@ using Mantle.DomainModels.Models;
 using Mantle.Loot.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -18,6 +19,8 @@ namespace Mantle.API.Controllers
     public class BaseWeaponCategoryController : ControllerBase
     {
         private IBaseWeaponCategoryLoot _baseWeaponCategoryLoot;
+        //TODO Note Logger in this app really only needs used for errors.
+        //  Additionally I should have a middleware that manages the injection and I just access that anytime I need it to force certain parameters to be passed to errors (Exception details, user, request, etc)
         private readonly ILogger<BaseWeaponCategoryController> _logger;
 
         public BaseWeaponCategoryController(IBaseWeaponCategoryLoot baseWeaponCategoryLoot,
@@ -33,6 +36,7 @@ namespace Mantle.API.Controllers
         [AllowAnonymous]
         public async Task<IEnumerable<BaseWeaponCategory>> Get()
         {
+            _logger.LogInformation($"User: {User.Claims.ToArray()[4].Value} Request URL: {Request.GetDisplayUrl()}");
             var domain = await _baseWeaponCategoryLoot.GetAllAsync();
             return domain;
         }
@@ -43,6 +47,7 @@ namespace Mantle.API.Controllers
         [AllowAnonymous]
         public async Task<BaseWeaponCategory> GetById(int id)
         {
+            _logger.LogInformation($"User: {User.Claims.ToArray()[4].Value} Request URL: {Request.GetDisplayUrl()}");
             var domain = await _baseWeaponCategoryLoot.GetByIdAsync(id);
             return domain;
         }

--- a/Mantle.API/Properties/launchSettings.json
+++ b/Mantle.API/Properties/launchSettings.json
@@ -23,7 +23,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:44361;http://localhost:50556"
     }
   }
 }


### PR DESCRIPTION
Also added some commentary for logging practices, and set the Mantle.API LaunchSettings to use the same ports that IIS Express initializes (this is primarily for using the Auth token between both sets of app start)